### PR TITLE
feat: spring security oauth2 add

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,12 +34,13 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
-	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
+	//providedRuntime
+	implementation 'org.springframework.boot:spring-boot-starter-tomcat'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'io.jsonwebtoken:jjwt:0.12.6'
-
+	runtimeOnly 'com.h2database:h2'
     /*
     *   [BJW]
     *   객체간의 매핑을 쉽게 하기 위해 ModelMapper 라이브러리를 추가

--- a/src/main/java/com/org/server/config/RedisConfig.java
+++ b/src/main/java/com/org/server/config/RedisConfig.java
@@ -1,0 +1,44 @@
+package com.org.server.config;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+        configuration.setHostName(host);
+        configuration.setPort(port);
+        configuration.setPassword(password);
+        return new LettuceConnectionFactory(configuration);
+    }
+    @Bean
+    public RedisTemplate<String,Object> redisTemplate(RedisConnectionFactory redisConnectionFactory){
+        RedisTemplate<String,Object> redisTemplate=new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/org/server/config/SecurityConfig.java
+++ b/src/main/java/com/org/server/config/SecurityConfig.java
@@ -1,0 +1,103 @@
+package com.org.server.config;
+
+
+import com.org.server.member.repository.MemberRepository;
+import com.org.server.redis.service.RedisUserInfoService;
+import com.org.server.security.detailservices.CustomOAuth2Service;
+import com.org.server.security.detailservices.CustomUserDetailService;
+import com.org.server.security.filters.JwtAuthFilter;
+import com.org.server.security.filters.TokenAuthfilter;
+import com.org.server.security.handlers.CustomLogOutHandler;
+import com.org.server.security.handlers.OAuth2FailHandler;
+import com.org.server.security.handlers.OAuth2SuccessHandler;
+import com.org.server.util.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailHandler oAuth2FailHandler;
+    private final CustomLogOutHandler customLogOutHandler;
+    private final RedisUserInfoService redisUserInfoService;
+    private final MemberRepository memberRepository;
+    private final WebConfig webConfig;
+    private final JwtUtil jwtUtil;
+
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http)throws Exception{
+
+
+        http.headers(headers -> headers
+                .httpStrictTransportSecurity(HeadersConfigurer.HstsConfig::disable)
+                .frameOptions(HeadersConfigurer.FrameOptionsConfig::disable)
+        );
+
+
+
+        http.logout(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable);
+
+        http.addFilterBefore(new JwtAuthFilter(redisUserInfoService,jwtUtil,authenticationManager()
+        ), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new TokenAuthfilter(jwtUtil,redisUserInfoService,memberRepository)
+                , JwtAuthFilter.class);
+
+        http.sessionManagement(session->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.oauth2Login(oauth2->
+                oauth2.userInfoEndpoint(userInfo->userInfo.userService(
+                        new CustomOAuth2Service(memberRepository)
+                        ))
+                        .successHandler(oAuth2SuccessHandler)
+                        .failureHandler(oAuth2FailHandler)
+        );
+
+        http.cors(c->c.configurationSource(webConfig.corsConfigurationSource()));
+
+        http.logout(logout -> logout
+                .logoutUrl("/logout")
+                .invalidateHttpSession(true)
+                .logoutSuccessHandler(customLogOutHandler)
+                .permitAll());
+
+        http.authorizeHttpRequests(req->
+                req.anyRequest().authenticated());
+
+        return http.build();
+    };
+
+    @Bean
+    public AuthenticationManager authenticationManager(){
+        DaoAuthenticationProvider provider=new DaoAuthenticationProvider(
+                new CustomUserDetailService(memberRepository)
+        );
+        provider.setPasswordEncoder(passwordEncoder());
+        return new ProviderManager(provider);
+    }
+
+
+}

--- a/src/main/java/com/org/server/config/WebConfig.java
+++ b/src/main/java/com/org/server/config/WebConfig.java
@@ -1,0 +1,41 @@
+package com.org.server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Configuration
+public class WebConfig{
+
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource(){
+        CorsConfiguration config=new CorsConfiguration();
+
+        /*
+         * 브라우저가 쿠키 혹은 AUTHROZATION같은 헤더를 포함할수있게 해주는 설정.
+         * */
+        config.setAllowCredentials(true);
+        config.setAllowedOrigins(List.of("http://localhost:3000"));
+        config.addAllowedMethod("*");
+        config.addAllowedHeader("*");
+
+        config.addExposedHeader(AUTHORIZATION);
+        /* 백엔드의 response에 담는 헤더르 프론트단에서 볼수있게 설정해주는것.*/
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        //경로마다 어떤 CORS정책을 설정할지를 말하는대 /**이므로 모든 겨올에대해서 COSR를 같은걸 적용한다 이말.
+
+        return source;
+    }
+
+}

--- a/src/main/java/com/org/server/exception/MoiraException.java
+++ b/src/main/java/com/org/server/exception/MoiraException.java
@@ -1,0 +1,7 @@
+package com.org.server.exception;
+
+public class MoiraException extends RuntimeException{
+    public MoiraException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/org/server/member/GenderType.java
+++ b/src/main/java/com/org/server/member/GenderType.java
@@ -1,0 +1,6 @@
+package com.org.server.member;
+
+public enum GenderType {
+
+    Male,Female
+}

--- a/src/main/java/com/org/server/member/MemberType.java
+++ b/src/main/java/com/org/server/member/MemberType.java
@@ -1,0 +1,6 @@
+package com.org.server.member;
+
+public enum MemberType {
+
+    KAKAO,LOCAL,NAVER,GOOGLE;
+}

--- a/src/main/java/com/org/server/member/domain/Member.java
+++ b/src/main/java/com/org/server/member/domain/Member.java
@@ -1,6 +1,8 @@
 package com.org.server.member.domain;
 
 
+import com.org.server.member.GenderType;
+import com.org.server.member.MemberType;
 import com.org.server.util.BaseTime;
 
 import jakarta.persistence.Entity;
@@ -22,11 +24,23 @@ public class Member extends BaseTime {
     private String email;
     private String nickName;
     private String password;
+    private MemberType memberType;
+    private GenderType genderType;
+    private String birthYear;
+    private String birthDay;
+    private String birthMonth;
 
     @Builder
-    public Member(String email, String nickName, String password) {
+    public Member(Long id, String email, String nickName, String password,
+                  MemberType memberType, GenderType genderType, String birthYear, String birthDay, String birthMonth) {
+        this.id = id;
         this.email = email;
         this.nickName = nickName;
         this.password = password;
+        this.memberType = memberType;
+        this.genderType = genderType;
+        this.birthYear = birthYear;
+        this.birthDay = birthDay;
+        this.birthMonth = birthMonth;
     }
 }

--- a/src/main/java/com/org/server/member/repository/MemberRepository.java
+++ b/src/main/java/com/org/server/member/repository/MemberRepository.java
@@ -1,4 +1,10 @@
 package com.org.server.member.repository;
 
-public interface MemberRepository {
+import com.org.server.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member,Long> {
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/org/server/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/org/server/member/repository/MemberRepositoryImpl.java
@@ -1,7 +1,0 @@
-package com.org.server.member.repository;
-
-import org.springframework.stereotype.Repository;
-
-@Repository
-public class MemberRepositoryImpl implements MemberRepository{
-}

--- a/src/main/java/com/org/server/redis/service/RedisUserInfoService.java
+++ b/src/main/java/com/org/server/redis/service/RedisUserInfoService.java
@@ -1,0 +1,28 @@
+package com.org.server.redis.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RedisUserInfoService {
+
+    private final RedisTemplate<String,String> redisTemplate;
+    private static final String refresh_token_key="X-REFRESH-KEY-";
+
+    public void saveRefreshToken(Long memberId, String refreshToken){
+        redisTemplate.opsForValue().set(refresh_token_key+memberId.toString(),refreshToken,
+                TimeUnit.DAYS.toDays(30L));
+    }
+    public String getRefreshToken(Long memberId){
+        return redisTemplate.opsForValue().get(refresh_token_key+memberId.toString());
+    }
+
+    public void delRefreshToken(Long memberId){
+        redisTemplate.opsForValue().getAndDelete(refresh_token_key+memberId.toString());
+    }
+}

--- a/src/main/java/com/org/server/security/detailservices/CustomOAuth2Service.java
+++ b/src/main/java/com/org/server/security/detailservices/CustomOAuth2Service.java
@@ -1,0 +1,98 @@
+package com.org.server.security.detailservices;
+
+import com.org.server.member.MemberType;
+import com.org.server.member.domain.Member;
+import com.org.server.member.repository.MemberRepository;
+import com.org.server.security.domain.*;
+import com.org.server.util.RandomCharSet;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.Optional;
+
+@Slf4j
+public class CustomOAuth2Service extends DefaultOAuth2UserService {
+
+    private  MemberRepository memberRepository;
+
+    public CustomOAuth2Service(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User userData=super.loadUser(userRequest);
+
+        String registrationId=userRequest.getClientRegistration().getRegistrationId();
+
+        OAuth2Response response=createOAuth2Response(registrationId,userData);
+
+        if(response==null){
+            throw new RuntimeException();
+        }
+        else{
+            log.info("{}-유저가 로그인 시도",registrationId);
+            Optional<Member> member=memberRepository.findByEmail(response.getEmail());
+            if(member.isPresent()){
+                return whenExistMember(member.get(),response.getProvider());
+            }
+            log.info("기존에 없는 {}-{}가 로그인 시도",response.getProvider(),response.getEmail());
+            return whenNotExistMember(response);
+        }
+
+    }
+    private OAuth2User whenExistMember(Member member, MemberType provider){
+        log.info("기존에 존재하는 {}-{} 가 로그인 시도",provider,member.getEmail());
+        return CustomOAuth2User
+                .builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .memberType(member.getMemberType())
+                .build();
+    }
+
+    @Transactional
+    private OAuth2User whenNotExistMember(OAuth2Response response){
+        Member newMember=Member.builder()
+                .email(response.getEmail())
+                .memberType(response.getProvider())
+                .nickName(RandomCharSet.createRandomName())
+                .genderType(response.getGender())
+                .birthDay(response.getBirthday())
+                .birthMonth(response.getBirthMonth())
+                .birthYear(response.getBirthYear())
+                .build();
+
+        memberRepository.save(newMember);
+        return CustomOAuth2User
+                .builder()
+                .id(newMember.getId())
+                .email(newMember.getEmail())
+                .memberType(newMember.getMemberType())
+                .build();
+    }
+
+    private OAuth2Response createOAuth2Response(String registrationId,OAuth2User userData){
+        switch (registrationId){
+            case "kakao" -> {
+                return new KakaoResponse(userData.getAttributes());
+            }
+            case "naver"->{
+                return new NaverResponse(userData.getAttributes());
+            }
+            case "google"->{
+                return  new GoogleResponse(userData.getAttributes());
+            }
+            default ->{
+                return null;
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/com/org/server/security/detailservices/CustomUserDetailService.java
+++ b/src/main/java/com/org/server/security/detailservices/CustomUserDetailService.java
@@ -1,0 +1,39 @@
+package com.org.server.security.detailservices;
+
+import com.org.server.member.MemberType;
+import com.org.server.member.domain.Member;
+import com.org.server.member.repository.MemberRepository;
+import com.org.server.security.domain.CustomUserDetail;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.Optional;
+
+
+@Slf4j
+public class CustomUserDetailService implements UserDetailsService {
+
+    private  MemberRepository memberRepository;
+
+    public CustomUserDetailService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<Member> member= memberRepository.findByEmail(username);
+        if(member.isEmpty()){
+            log.info("{} 는 없는 사용자입니다.",username);
+            throw new RuntimeException();
+        }
+        if(member.get().getMemberType()!= MemberType.LOCAL){
+            log.info("{}는 일반 회원이 아닙니다",username);
+            throw new RuntimeException();
+        }
+        log.info("로컬 유저-{} 로그인 시도중",member.get().getEmail());
+        return new CustomUserDetail(member.get());
+    }
+}

--- a/src/main/java/com/org/server/security/domain/CustomOAuth2User.java
+++ b/src/main/java/com/org/server/security/domain/CustomOAuth2User.java
@@ -1,0 +1,60 @@
+package com.org.server.security.domain;
+
+import com.org.server.member.MemberType;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+@Getter
+public class CustomOAuth2User implements OAuth2User{
+    private Long id;
+    private String memberRole;
+    private MemberType memberType;
+    private String email;
+
+    @Builder
+    public CustomOAuth2User(Long id, String memberRole,
+                            MemberType memberType, String email) {
+        this.id = id;
+        this.memberRole = memberRole;
+        this.memberType = memberType;
+        this.email = email;
+    }
+
+    @Override
+    public <A> A getAttribute(String name) {
+        return OAuth2User.super.getAttribute(name);
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection=new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return memberRole;
+            }
+        });
+
+        return collection;
+    }
+
+
+    //이거 안쓰긴하는대 뭔가값이 들어있긴 해야되나보다.
+    @Override
+    public String getName() {
+        return "dont use";
+    }
+}

--- a/src/main/java/com/org/server/security/domain/CustomUserDetail.java
+++ b/src/main/java/com/org/server/security/domain/CustomUserDetail.java
@@ -1,0 +1,51 @@
+package com.org.server.security.domain;
+
+import com.org.server.member.domain.Member;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.UUID;
+
+@Getter
+public class CustomUserDetail implements UserDetails {
+
+    private Member member;
+    public CustomUserDetail(Member member) {
+        this.member = member;
+    }
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+    public Long getMemberId(){
+        return member.getId();
+    }
+
+}

--- a/src/main/java/com/org/server/security/domain/GoogleResponse.java
+++ b/src/main/java/com/org/server/security/domain/GoogleResponse.java
@@ -1,0 +1,45 @@
+package com.org.server.security.domain;
+
+import com.org.server.member.GenderType;
+import com.org.server.member.MemberType;
+
+import java.util.Map;
+
+public class GoogleResponse implements OAuth2Response{
+
+    private Map<String,Object> attrs;
+
+    public GoogleResponse(Map<String, Object> attrs) {
+        this.attrs = attrs;
+    }
+
+    @Override
+    public MemberType getProvider() {
+        return MemberType.GOOGLE;
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attrs.get("email");
+    }
+
+    @Override
+    public String getBirthday() {
+        return null;
+    }
+
+    @Override
+    public String getBirthYear() {
+        return null;
+    }
+
+    @Override
+    public String getBirthMonth() {
+        return null;
+    }
+
+    @Override
+    public GenderType getGender() {
+        return null;
+    }
+}

--- a/src/main/java/com/org/server/security/domain/KakaoResponse.java
+++ b/src/main/java/com/org/server/security/domain/KakaoResponse.java
@@ -1,0 +1,48 @@
+package com.org.server.security.domain;
+
+import com.org.server.member.GenderType;
+import com.org.server.member.MemberType;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static com.org.server.member.MemberType.KAKAO;
+
+public class KakaoResponse implements OAuth2Response {
+    private final Map<String,Object> attributes;
+    public KakaoResponse(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+    private Map<String,Object> KakaoAccount(Map<String,Object> attr){
+        return (Map<String, Object>) attr.getOrDefault("kakao_account", Collections.emptyMap());
+    }
+    @Override
+    public MemberType getProvider() {
+        return KAKAO;
+    }
+    @Override
+    public String getEmail() {
+        return (String) KakaoAccount(attributes).get("email");
+    }
+    @Override
+    public String getBirthday() {
+        String brith=(String)KakaoAccount(attributes).get("birthday");
+        return brith.substring(2,3);
+    }
+    @Override
+    public String getBirthYear() {
+        return (String)KakaoAccount(attributes).get("birthyear");
+    }
+    @Override
+    public String getBirthMonth() {
+        String brith=(String)KakaoAccount(attributes).get("birthday");
+        return brith.substring(0,1);
+    }
+    @Override
+    public GenderType getGender() {
+        return (GenderType) KakaoAccount(attributes).get("gender");
+    }
+
+
+
+}

--- a/src/main/java/com/org/server/security/domain/NaverResponse.java
+++ b/src/main/java/com/org/server/security/domain/NaverResponse.java
@@ -1,0 +1,52 @@
+package com.org.server.security.domain;
+
+import com.org.server.member.GenderType;
+import com.org.server.member.MemberType;
+import org.antlr.v4.runtime.atn.SemanticContext;
+
+import javax.print.attribute.standard.MediaSize;
+import java.util.Collections;
+import java.util.Map;
+
+import static com.org.server.member.MemberType.NAVER;
+
+public class NaverResponse implements OAuth2Response{
+
+    private final Map<String,Object> attributes;
+    public NaverResponse(Map<String,Object> attributes) {
+        this.attributes=attributes;
+    }
+    private Map<String,Object> getAttrs(){
+        return (Map<String, Object>)
+                attributes.getOrDefault("response", Collections.emptyMap());
+    }
+    @Override
+    public MemberType getProvider() {
+        return NAVER;
+    }
+    @Override
+    public String getEmail() {
+        return (String) getAttrs().get("email");
+    }
+    @Override
+    public String getBirthday() {
+
+        String birth=(String) getAttrs().get("birthday");
+        return birth.split("-")[1];
+    }
+    @Override
+    public String getBirthYear() {
+        return (String) getAttrs().get("year");
+    }
+    @Override
+    public String getBirthMonth() {
+        String birth=(String) getAttrs().get("birthday");
+        return birth.split("-")[0];
+    }
+    @Override
+    public GenderType getGender() {
+        String gender=(String) getAttrs().get("gender");
+        return gender.equals("F") ? GenderType.Female :
+                gender.equals("U") ? null:GenderType.Male;
+    }
+}

--- a/src/main/java/com/org/server/security/domain/OAuth2Response.java
+++ b/src/main/java/com/org/server/security/domain/OAuth2Response.java
@@ -1,0 +1,13 @@
+package com.org.server.security.domain;
+
+import com.org.server.member.GenderType;
+import com.org.server.member.MemberType;
+
+public interface OAuth2Response {
+    MemberType getProvider();
+    String getEmail();
+    String getBirthday();
+    String getBirthYear();
+    String getBirthMonth();
+    GenderType getGender();
+}

--- a/src/main/java/com/org/server/security/filters/JwtAuthFilter.java
+++ b/src/main/java/com/org/server/security/filters/JwtAuthFilter.java
@@ -1,0 +1,97 @@
+package com.org.server.security.filters;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.org.server.redis.service.RedisUserInfoService;
+import com.org.server.security.domain.CustomUserDetail;
+import com.org.server.util.jwt.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import static com.org.server.util.jwt.TokenEnum.TOKEN_PREFIX;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Slf4j
+public class JwtAuthFilter extends UsernamePasswordAuthenticationFilter {
+
+    private  RedisUserInfoService redisUserInfoService;
+    private  JwtUtil jwtUtils;
+    private  AuthenticationManager authenticationManager;
+
+    public JwtAuthFilter(RedisUserInfoService redisUserInfoService, JwtUtil jwtUtils
+    ,AuthenticationManager authenticationManager) {
+        this.redisUserInfoService = redisUserInfoService;
+        this.jwtUtils = jwtUtils;
+        this.authenticationManager=authenticationManager;
+    }
+    @Override
+    public void setFilterProcessesUrl(String filterProcessesUrl) {
+        this.setRequiresAuthenticationRequestMatcher(
+                new OrRequestMatcher(
+                        new RequestMatcher() {
+                            @Override
+                            public boolean matches(HttpServletRequest request) {
+                                return request.getRequestURI().equals("/login");
+                            }
+                        }
+                )
+        );
+    }
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        try(InputStream inputStream=request.getInputStream()) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            Map<String, String> data = objectMapper.readValue(inputStream, Map.class);
+            String mail=data.get("mail");
+            String password=data.get("password");
+            UsernamePasswordAuthenticationToken token=
+                    new UsernamePasswordAuthenticationToken(mail,password);
+            return token;
+        }
+        catch (IOException e){
+            log.debug("유저정보 파싱중 발생한 에러");
+            throw new RuntimeException();
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+        CustomUserDetail userDetail=(CustomUserDetail) authResult.getPrincipal();
+
+        String accessToken=jwtUtils.genAccessToken(userDetail.getMemberId());
+        String refreshToken=jwtUtils.genRefreshToken(userDetail.getMemberId());
+        redisUserInfoService.saveRefreshToken(userDetail.getMemberId(),refreshToken);
+        response.setHeader(AUTHORIZATION,TOKEN_PREFIX.getValue()+accessToken);
+        response.setStatus(200);
+    }
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                              AuthenticationException failed) throws IOException, ServletException {
+        if(failed.getClass().getSimpleName().equals("BadCredentialsException")){
+            sendErrorResponse(response,HttpStatus.BAD_REQUEST,"비밀번호가 일치하지 않습니다.");
+            return ;
+        }
+        sendErrorResponse(response,HttpStatus.UNAUTHORIZED,failed.getMessage());
+    }
+    private void sendErrorResponse(HttpServletResponse response, HttpStatus httpStatus, String message) throws
+            IOException {
+        response.setStatus(httpStatus.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(String.format("{\"message\":\"%s\",\"status\":\"%s\"}", message, httpStatus.name()));
+    }
+}

--- a/src/main/java/com/org/server/security/filters/TokenAuthfilter.java
+++ b/src/main/java/com/org/server/security/filters/TokenAuthfilter.java
@@ -1,0 +1,89 @@
+package com.org.server.security.filters;
+
+import com.org.server.member.repository.MemberRepository;
+import com.org.server.redis.service.RedisUserInfoService;
+import com.org.server.security.domain.CustomUserDetail;
+import com.org.server.util.jwt.JwtUtil;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static com.org.server.util.jwt.TokenEnum.TOKEN_PREFIX;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Slf4j
+
+public class TokenAuthfilter extends OncePerRequestFilter {
+
+    private JwtUtil jwtUtil;
+    private RedisUserInfoService redisUserInfoService;
+    private MemberRepository memberRepository;
+
+    public TokenAuthfilter(JwtUtil jwtUtil, RedisUserInfoService redisUserInfoService,
+                           MemberRepository memberRepository) {
+        this.jwtUtil = jwtUtil;
+        this.redisUserInfoService = redisUserInfoService;
+        this.memberRepository = memberRepository;
+    }
+
+    private static final String[] freePassPath = {"/login"
+    };
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getRequestURI();
+        return Arrays.stream(freePassPath).anyMatch(path::startsWith);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String authorization=request.getHeader(AUTHORIZATION);
+        String accessToken=jwtUtil.getTokenFromHeader(authorization);
+        Claims claims;
+        if(accessToken==null){
+            sendErrorResponse(response,HttpStatus.BAD_REQUEST,"토큰이 없습니다");
+            return ;
+        }
+        if(!jwtUtil.validToken(accessToken)){
+            sendErrorResponse(response,HttpStatus.BAD_REQUEST,"유효하지 않은 토큰입니다");
+            return ;
+        }
+        claims=jwtUtil.getClaims(accessToken);
+        if(jwtUtil.isExpire(accessToken)){
+            String refreshToken=redisUserInfoService.getRefreshToken(claims.get("id",Long.class));
+            if(refreshToken==null||jwtUtil.isExpire(refreshToken)){
+                response.sendRedirect("redirect");
+                return ;
+            }
+            accessToken=jwtUtil.genAccessToken(claims.get("id", Long.class));
+            response.setHeader(AUTHORIZATION,TOKEN_PREFIX.getValue()+accessToken);
+        }
+        CustomUserDetail customUserDetail=
+                new CustomUserDetail(memberRepository.findById(claims.get("id",Long.class)).get());
+        Authentication auth=new UsernamePasswordAuthenticationToken(
+                customUserDetail,null,customUserDetail.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        filterChain.doFilter(request,response);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, HttpStatus httpStatus, String message) throws
+            IOException {
+        response.setStatus(httpStatus.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(String.format("{\"message\":\"%s\",\"status\":\"%s\"}", message, httpStatus.name()));
+    }
+
+}

--- a/src/main/java/com/org/server/security/handlers/CustomLogOutHandler.java
+++ b/src/main/java/com/org/server/security/handlers/CustomLogOutHandler.java
@@ -1,0 +1,51 @@
+package com.org.server.security.handlers;
+
+import com.org.server.redis.service.RedisUserInfoService;
+import com.org.server.util.jwt.JwtUtil;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class CustomLogOutHandler implements LogoutSuccessHandler {
+
+    private final RedisUserInfoService redisUserInfoService;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        String authorization=request.getHeader(AUTHORIZATION);
+        String token=jwtUtil.getTokenFromHeader(authorization);
+        if(token==null){
+          sendErrorResponse(response,HttpStatus.BAD_REQUEST,"토큰이 없습니다");
+          return;
+        }
+        Claims claims=jwtUtil.getClaims(token);
+        redisUserInfoService.delRefreshToken(claims.get("id",Long.class));
+        SecurityContextHolder.clearContext();;
+        log.info("로그아웃이 성공적으로 처리되었습니다");
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, HttpStatus httpStatus, String message) throws
+            IOException {
+        response.setStatus(httpStatus.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(String.format("{\"message\":\"%s\",\"status\":\"%s\"}", message, httpStatus.name()));
+    }
+
+}

--- a/src/main/java/com/org/server/security/handlers/OAuth2FailHandler.java
+++ b/src/main/java/com/org/server/security/handlers/OAuth2FailHandler.java
@@ -1,0 +1,27 @@
+package com.org.server.security.handlers;
+
+import com.org.server.member.GenderType;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2FailHandler implements AuthenticationFailureHandler {
+
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response, AuthenticationException exception)
+            throws IOException, ServletException {
+        response.setContentType("application/json; charset=UTF-8");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.getWriter().write("{\"error\": \"OAUTH2_LOGIN_ERROR\", \"message\": \"" + exception.getMessage() + "\"}");
+        log.info("oauth2 로그인 실패: {}", exception.getMessage());
+    }
+}

--- a/src/main/java/com/org/server/security/handlers/OAuth2SuccessHandler.java
+++ b/src/main/java/com/org/server/security/handlers/OAuth2SuccessHandler.java
@@ -1,0 +1,44 @@
+package com.org.server.security.handlers;
+
+import com.org.server.redis.service.RedisUserInfoService;
+import com.org.server.security.domain.CustomOAuth2User;
+import com.org.server.util.jwt.JwtUtil;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import static com.org.server.util.jwt.TokenEnum.TOKEN_PREFIX;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtils;
+    private final RedisUserInfoService redisUserInfoService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        CustomOAuth2User customOAuth2User=(CustomOAuth2User) authentication.getPrincipal();
+
+        String accessToken= jwtUtils.genAccessToken(customOAuth2User.getId());
+        String refreshToken=jwtUtils.genRefreshToken(customOAuth2User.getId());
+
+        redisUserInfoService.saveRefreshToken(customOAuth2User.getId(),refreshToken);
+        response.addHeader(AUTHORIZATION,TOKEN_PREFIX.getValue()+accessToken);
+
+        //로컬에서 테스트시 원하는 주소로 바꾸시면됩니다.
+        response.sendRedirect("http://localhost:3000/login");
+
+        log.info("{} 유저에대한 로그인이 정상적으로 되었습니다",customOAuth2User.getEmail());
+    }
+}

--- a/src/main/java/com/org/server/util/RandomCharSet.java
+++ b/src/main/java/com/org/server/util/RandomCharSet.java
@@ -1,0 +1,21 @@
+package com.org.server.util;
+
+import java.util.Random;
+
+public class RandomCharSet {
+
+    private static final String [] randomChar=new String[] {
+            "A","B","C","D","E","F","G","H","1","2","3","4","5","6","7","8","9","0"
+            ,"J","K","L","Z","X","C","V","N","M"
+    };
+
+    public static String createRandomName(){
+        String name="";
+        for(int i=0;i<10;i++){
+            Random random = new Random();
+            int number = random.nextInt(27); // 0 ~ 26 포함;
+            name+=randomChar[number];
+        }
+        return name;
+    }
+}

--- a/src/main/java/com/org/server/util/jwt/JwtUtil.java
+++ b/src/main/java/com/org/server/util/jwt/JwtUtil.java
@@ -1,0 +1,85 @@
+package com.org.server.util.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.time.Duration;
+import java.util.Date;
+import java.util.UUID;
+
+import static com.org.server.util.jwt.TokenEnum.TOKEN_PREFIX;
+
+@Component
+public class JwtUtil {
+    @Value("${jwt.secret-key}")
+    private String signKey;
+
+    @Value("${jwt.issuer}")
+    private String issuer;
+
+    private String makeToken(Long memberId, TokenEnum tokenCategory
+            , Date date, Duration duration){
+        return Jwts.builder()
+                .issuer(issuer)
+                .issuedAt(date)
+                .expiration(new Date(date.getTime()+duration.toMillis()))
+                .claim("id",memberId)
+                .claim("category",tokenCategory.getValue())
+                .signWith(getSignKey())
+                .compact();
+    }
+    public  String genRefreshToken(Long memberId){
+        return makeToken(memberId, TokenEnum.REFRESH,new Date(),Duration.ofDays(30L));
+    }
+    public  String genAccessToken(Long memberId){
+        return makeToken(memberId, TokenEnum.ACCESS,new Date(),Duration.ofDays(1L));
+    }
+    private SecretKey getSignKey(){
+        return Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(signKey));
+    }
+
+
+    private Claims getClaimsFromToken(String token){
+        Jws<Claims> claims=Jwts.parser()
+                .verifyWith(getSignKey()).build().parseSignedClaims(token);
+        return claims.getPayload();
+    }
+
+    public Claims getClaims(String token){
+        try{
+            return getClaimsFromToken(token);
+        }
+        catch (ExpiredJwtException e){
+            return e.getClaims();
+        }
+    }
+    public boolean isExpire(String token){
+        return Jwts.parser().verifyWith(getSignKey()).build().parseSignedClaims(token)
+                .getPayload().getExpiration().before(new Date());
+    }
+    public Boolean validToken(String token){
+        try{
+            Claims claims=getClaims(token);
+            return true;
+        }
+        catch (ExpiredJwtException e) {
+            return true;
+        }
+        catch (Exception e){
+            return false;
+        }
+    }
+    public String getTokenFromHeader(String authorizationHeader){
+        if(authorizationHeader!=null&&authorizationHeader.startsWith(TOKEN_PREFIX.getValue())){
+            return authorizationHeader.replace(TOKEN_PREFIX.getValue(),"");
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/org/server/util/jwt/TokenEnum.java
+++ b/src/main/java/com/org/server/util/jwt/TokenEnum.java
@@ -1,0 +1,15 @@
+package com.org.server.util.jwt;
+
+public enum TokenEnum {
+    ACCESS("access"),REFRESH("refresh"),TOKEN_PREFIX("Bearer ");
+
+    String value;
+
+    TokenEnum(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,71 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:~/playhive;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    open-in-view: false
+    properties:
+      hibernate:
+        default_batch_fetch_size: 100
+        jdbc:
+          exception-handling: ignore
+
+  security:
+    oauth2:
+      client:
+        registration:
+          naver:
+            client-name: naver
+            client-id:
+            client-secret:
+            authorization-grant-type: authorization_code
+            scope:
+              - email
+              - gender
+              - birthday
+              - birthyear
+            redirect-uri: "{baseUrl}/{action}/oauth2/code/{registrationId}"
+          google:
+            client-name: google
+            client-id:
+            client-secret:
+            scope:
+              - email
+          kakao:
+            client-name: kakao
+            client-id:
+            client-secret:
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope:
+              - account_email
+              - gender
+              - birthday
+              - birthyear
+            redirect-uri: "{baseUrl}/{action}/oauth2/code/{registrationId}"
+        provider:
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-info-authentication-method: header
+            user-name-attribute: id # Kakao 응답 값 id, connected_at, properties, kakao_account 중 id 지정
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: test
+
+jwt:
+  issuer: "JWT_ISSUER"
+  secret-key: "mySuperSecretKeyForJwtAuthThatIsLongEnough1234"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,4 +2,33 @@ spring:
   application:
     name: server
 
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url:
+    username:
+    password:
 
+  jpa:
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+        use_sql_comments: false
+        default_batch_fetch_size: 1000 #최적화 옵션
+        jdbc:
+          time_zone: Asia/Seoul
+    hibernate:
+      ddl-auto: none
+      #  create	기존테이블을 삭제하고 다시 생성
+      #  create-drop 기존테이블을 삭제하고 다시생성. 종료 시점에 테이블삭제
+      #  update	변경된 스키마 적용 (운영 DB 에서 사용X)
+      #  validate Entity 와 테이블이 정상 매핑 되었는지 확인
+      #  none 기존테이블을 더 이상 건드리지 않음.
+    open-in-view: true
+
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: test

--- a/src/test/java/com/org/server/support/IntegralTestEnv.java
+++ b/src/test/java/com/org/server/support/IntegralTestEnv.java
@@ -1,0 +1,35 @@
+package com.org.server.support;
+
+
+import com.org.server.member.domain.Member;
+import com.org.server.member.repository.MemberRepository;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+public class IntegralTestEnv {
+
+    @Autowired
+    protected MemberRepository memberRepository;
+
+
+    @AfterEach
+    void deleteAll(){
+        memberRepository.deleteAllInBatch();
+    }
+
+
+
+    protected Member createMember(Long idx){
+
+        Member member=Member.builder()
+                .email("test@"+idx+"test.com")
+                .nickName("test"+idx)
+                .password("1234")
+                .build();
+        member=memberRepository.save(member);
+        return member;
+    }
+}


### PR DESCRIPTION
스프링 시큐리티 oauth2 로그인 관련한 기능 구현입니다.
현재 로컬에서 재 개인 구글,네이버 키로 진행했을떄 정상적으로 진행되는것이 확인되었고
카카오의 경우에는 추가적으로 요구 사항을 만족을해야 진행이되서 카카오는 추후에 진행하겠습니다.

참고로 memberrepository의 경우 impl클래스를 만들지 않고 그냥 간단하게 japrepository를 상속받아서 쓰는게 좋지 않나싶어서 삭제했습니다.