### PR TITLE
feat: mail certification logic add

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt:0.12.6'
 	runtimeOnly 'com.h2database:h2'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '3.3.4'
     /*
     *   [BJW]
     *   객체간의 매핑을 쉽게 하기 위해 ModelMapper 라이브러리를 추가

--- a/src/main/java/com/org/server/Mail/AbstractMailSend.java
+++ b/src/main/java/com/org/server/Mail/AbstractMailSend.java
@@ -1,0 +1,58 @@
+package com.org.server.Mail;
+
+
+import ch.qos.logback.core.joran.conditional.ThenAction;
+import com.org.server.exception.MoiraException;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMailMessage;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@RequiredArgsConstructor
+public abstract class AbstractMailSend<T> implements MailSend<T>{
+
+    @Value("${spring.mail.username}")
+    protected String sender;
+
+    protected final JavaMailSender javaMailSender;
+    protected final SpringTemplateEngine templateEngine;
+
+    protected abstract String makeSubject();
+    protected abstract  String makeBody(String email,T data);
+
+    @Override
+    public void sendMail(String email,T data) {
+        try{
+            String subject=makeSubject();
+            String body=makeBody(email,data);
+            MimeMessage message=createMimeMsg(email,subject,body);
+            javaMailSender.send(message);
+
+        }
+        catch (Exception e){
+            throw new MoiraException("서버에러 발생",HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public MimeMessage createMimeMsg(String email,String subject,String body){
+        MimeMessage message=javaMailSender.createMimeMessage();
+        try{
+            MimeMessageHelper helper =
+                    new MimeMessageHelper(message, true, "UTF-8");
+            helper.setFrom(sender);
+            helper.setSubject(subject);
+            helper.setTo(email);
+            helper.setText(body,true);
+        }
+        catch (Exception e){
+            throw new MoiraException("서버에러 발생", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        return message;
+    };
+}

--- a/src/main/java/com/org/server/Mail/CertificationMail.java
+++ b/src/main/java/com/org/server/Mail/CertificationMail.java
@@ -1,0 +1,42 @@
+package com.org.server.Mail;
+
+import com.org.server.redis.service.RedisUserInfoService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+
+@Component
+@Slf4j
+public class CertificationMail extends AbstractMailSend<String>{
+
+    public CertificationMail(JavaMailSender javaMailSender, SpringTemplateEngine templateEngine) {
+        super(javaMailSender, templateEngine);
+
+    }
+    @Override
+    protected String makeSubject() {
+        return "회원가입 인증코드 메일입니다";
+    }
+    @Override
+    protected String makeBody(String email,String data) {
+        log.info("certification mail 호출");
+        Context context=new Context();
+        context.setVariable("인증코드",data);
+        /*
+        * 인증코드 만든느 로직 추가.
+        * */
+        return templateEngine.process("mail/certification-code",context);
+    }
+    @Override
+    public EmailType checkType() {
+        return EmailType.CERTIFICATION;
+    }
+
+}

--- a/src/main/java/com/org/server/Mail/EmailType.java
+++ b/src/main/java/com/org/server/Mail/EmailType.java
@@ -1,0 +1,6 @@
+package com.org.server.Mail;
+
+public enum EmailType {
+
+    CERTIFICATION
+}

--- a/src/main/java/com/org/server/Mail/MailFactory.java
+++ b/src/main/java/com/org/server/Mail/MailFactory.java
@@ -1,0 +1,31 @@
+package com.org.server.Mail;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class MailFactory {
+    private final Map<EmailType,MailSend<?>> mailMap=new HashMap<>();
+
+
+    //mailsendList는 mailsend라는 타입을 가지는 컴포넌트들을 모아서 di해준다 알아서.
+    public MailFactory(List<MailSend<?>> mailSendList) {
+        for(MailSend<?> mailSend:mailSendList){
+            mailMap.put(mailSend.checkType(),mailSend);
+        }
+    }
+    public <T> MailSend<T> supplyMailSend(EmailType emailType,Class<T> clazz){
+        if(emailType==EmailType.CERTIFICATION){
+            log.info("적당한 전략 전달");
+            return (MailSend<T>) mailMap.get(emailType);
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/org/server/Mail/MailSend.java
+++ b/src/main/java/com/org/server/Mail/MailSend.java
@@ -1,0 +1,12 @@
+package com.org.server.Mail;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+
+public interface MailSend<T> {
+
+
+    EmailType checkType();
+    void sendMail(String email,T data);
+}

--- a/src/main/java/com/org/server/certification/controller/CertificationController.java
+++ b/src/main/java/com/org/server/certification/controller/CertificationController.java
@@ -1,0 +1,31 @@
+package com.org.server.certification.controller;
+
+
+import com.org.server.certification.service.CertificationService;
+import com.org.server.util.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/cert")
+public class CertificationController {
+
+    private final CertificationService certificationService;
+    @GetMapping("/create/{mail}")
+    public ResponseEntity<ApiResponse<String>> createCode(@PathVariable(name ="mail")String mail){
+        certificationService.createCertCode(mail);
+        return ResponseEntity.ok(ApiResponse.CreateApiResponse("ok",null));
+    }
+
+    @GetMapping("/check/{mail}/{code}")
+    public ResponseEntity<ApiResponse<String>> checkCode(@PathVariable(name = "mail")String mail,
+                                                         @PathVariable(name="code")String code){
+        certificationService.checkCode(mail,code);
+        return ResponseEntity.ok(ApiResponse.CreateApiResponse("ok",null));
+    }
+}

--- a/src/main/java/com/org/server/certification/service/CertificationService.java
+++ b/src/main/java/com/org/server/certification/service/CertificationService.java
@@ -1,0 +1,34 @@
+package com.org.server.certification.service;
+
+
+import com.org.server.Mail.EmailType;
+import com.org.server.Mail.MailFactory;
+import com.org.server.Mail.MailSend;
+import com.org.server.exception.MoiraException;
+import com.org.server.redis.service.RedisUserInfoService;
+import com.org.server.util.RandomCharSet;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CertificationService {
+
+
+    private final MailFactory mailFactory;
+    private final RedisUserInfoService redisUserInfoService;
+    public void createCertCode(String email){
+        MailSend<String> mailSend=mailFactory.supplyMailSend(EmailType.CERTIFICATION, String.class);
+        String code= RandomCharSet.createRandomName();
+        redisUserInfoService.setCertCode(email,code);
+        mailSend.sendMail(email,code);
+    }
+
+    public void checkCode(String email,String code){
+        if(redisUserInfoService.checkCertCode(email,code)){
+            return ;
+        }
+        throw new MoiraException("인증코드가 일치하지않습니다",HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/org/server/config/SecurityConfig.java
+++ b/src/main/java/com/org/server/config/SecurityConfig.java
@@ -38,6 +38,10 @@ public class SecurityConfig {
     private final JwtUtil jwtUtil;
 
 
+    private final static String [] freePassUrl={
+            "/cert/**",
+    };
+
     @Bean
     public BCryptPasswordEncoder passwordEncoder(){
         return new BCryptPasswordEncoder();
@@ -85,7 +89,8 @@ public class SecurityConfig {
                 .permitAll());
 
         http.authorizeHttpRequests(req->
-                req.anyRequest().authenticated());
+                req.requestMatchers(freePassUrl).permitAll()
+                        .anyRequest().authenticated());
 
         return http.build();
     };

--- a/src/main/java/com/org/server/redis/service/RedisUserInfoService.java
+++ b/src/main/java/com/org/server/redis/service/RedisUserInfoService.java
@@ -13,6 +13,7 @@ public class RedisUserInfoService {
 
     private final RedisTemplate<String,String> redisTemplate;
     private static final String refresh_token_key="X-REFRESH-KEY-";
+    private static final String mail_cert_key="MAIL-CERT-";
 
     public void saveRefreshToken(Long memberId, String refreshToken){
         redisTemplate.opsForValue().set(refresh_token_key+memberId.toString(),refreshToken,
@@ -24,5 +25,18 @@ public class RedisUserInfoService {
 
     public void delRefreshToken(Long memberId){
         redisTemplate.opsForValue().getAndDelete(refresh_token_key+memberId.toString());
+    }
+
+    public void setCertCode(String email,String code){
+        redisTemplate.opsForValue().set(mail_cert_key+email,code,5L,TimeUnit.MINUTES);
+    }
+
+    public boolean checkCertCode(String email,String code){
+        String codeToCheck=redisTemplate.opsForValue().get(mail_cert_key+email);
+        if(codeToCheck!=null&&code.equals(codeToCheck)){
+            redisTemplate.delete(mail_cert_key+email);
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/org/server/security/filters/TokenAuthfilter.java
+++ b/src/main/java/com/org/server/security/filters/TokenAuthfilter.java
@@ -37,7 +37,7 @@ public class TokenAuthfilter extends OncePerRequestFilter {
         this.memberRepository = memberRepository;
     }
 
-    private static final String[] freePassPath = {"/login"
+    private static final String[] freePassPath = {"/login","/cert"
     };
 
     @Override

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -65,7 +65,20 @@ spring:
       host: localhost
       port: 6379
       password: test
-
+  mail :
+    host : smtp.gmail.com
+    port : 587
+    username :
+    password :
+    properties :
+      mail :
+        smtp :
+          auth : true
+          starttls :
+            enable : true
 jwt:
   issuer: "JWT_ISSUER"
   secret-key: "mySuperSecretKeyForJwtAuthThatIsLongEnough1234"
+
+
+

--- a/src/main/resources/templates/mail/certification-code.html
+++ b/src/main/resources/templates/mail/certification-code.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>회원가입 인증 코드</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f5f5f5;
+            padding: 20px;
+        }
+        .email-container {
+            background-color: #ffffff;
+            border-radius: 8px;
+            padding: 20px;
+            max-width: 600px;
+            margin: auto;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+        }
+        .code {
+            font-size: 24px;
+            font-weight: bold;
+            color: #2c3e50;
+            text-align: center;
+            margin: 20px 0;
+        }
+        .footer {
+            font-size: 12px;
+            color: #999999;
+            text-align: center;
+            margin-top: 20px;
+        }
+    </style>
+</head>
+<body>
+<div class="email-container">
+    <h2>안녕하세요!</h2>
+    <p>회원가입 인증을 위해 아래 코드를 입력해주세요.</p>
+    <div class="code" th:text="${인증코드}">123456</div>
+    <p>만약 요청하지 않으셨다면, 이 메일을 무시해주세요.</p>
+    <div class="footer">
+        © 2025 Your Company. All rights reserved.
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/com/org/server/certification/CertificationTest.java
+++ b/src/test/java/com/org/server/certification/CertificationTest.java
@@ -1,0 +1,55 @@
+package com.org.server.certification;
+
+import com.org.server.Mail.EmailType;
+import com.org.server.Mail.MailFactory;
+import com.org.server.Mail.MailSend;
+import com.org.server.redis.service.RedisUserInfoService;
+import com.org.server.support.IntegralTestEnv;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.mockito.Mockito.when;
+
+
+public class CertificationTest extends IntegralTestEnv {
+
+
+    @MockitoBean
+    MailFactory mailFactory;
+
+    @Test
+    @DisplayName("인증 코드 생성시에 각 메서드가 잘호출이되는가")
+    void testingCertificationCreateCall(){
+        String email="Zxczx";
+        MailSend<String> mailSend=Mockito.mock(MailSend.class);
+        when(mailFactory.supplyMailSend(EmailType.CERTIFICATION,String.class))
+                        .thenReturn(mailSend);
+        Mockito.doNothing()
+                .when(redisUserInfoService)
+                .setCertCode(Mockito.any(String.class), Mockito.any(String.class));
+        Mockito.doNothing()
+                .when(mailSend)
+                .sendMail(Mockito.any(String.class), Mockito.any(String.class));
+        certificationService.createCertCode(email);
+        Mockito.verify(redisUserInfoService).setCertCode(Mockito.any(String.class),Mockito.any(String.class));
+        Mockito.verify(mailSend).sendMail(Mockito.any(String.class),Mockito.any(String.class));
+    }
+
+    @Test
+    @DisplayName("인증 코드 확인시 호출 체크")
+    void testingCertificationCheckCall(){
+        String email="Zxczx";
+        String code="Zxczxcx";
+
+        Mockito.when(redisUserInfoService.checkCertCode(email,
+                        code))
+                .thenReturn(true);
+        certificationService.checkCode(email,code);
+        Mockito.verify(redisUserInfoService).checkCertCode(email,code);
+    }
+}

--- a/src/test/java/com/org/server/support/IntegralTestEnv.java
+++ b/src/test/java/com/org/server/support/IntegralTestEnv.java
@@ -1,18 +1,25 @@
 package com.org.server.support;
 
 
+import com.org.server.certification.CertificationTest;
+import com.org.server.certification.service.CertificationService;
 import com.org.server.member.MemberType;
 import com.org.server.member.domain.Member;
 import com.org.server.member.repository.MemberRepository;
 import com.org.server.member.service.MemberServiceImpl;
 import com.org.server.member.service.SecurityMemberReadService;
+import com.org.server.redis.service.RedisUserInfoService;
 import com.org.server.util.jwt.JwtUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.thymeleaf.spring6.SpringTemplateEngine;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -32,11 +39,21 @@ public class IntegralTestEnv {
     protected SecurityMemberReadService securityMemberReadService;
 
     @Autowired
-    protected JwtUtil jwtUtil;
-
+    protected CertificationService certificationService;
+    @MockitoBean
+    protected RedisUserInfoService redisUserInfoService;
 
     @Autowired
+    protected JwtUtil jwtUtil;
+
+    //else
+    @Autowired
     protected PasswordEncoder passwordEncoder;
+
+    @MockitoBean
+    protected JavaMailSender javaMailSender;
+    @MockitoBean
+    protected SpringTemplateEngine springTemplateEngine;
     @AfterEach
     void deleteAll(){
         memberRepository.deleteAllInBatch();


### PR DESCRIPTION
일반회원 가입시에 이메일 인증 기능추가.

post는 귀찮을거같아서 get으로 구현하였습니다.

로컬에서 구글smtp사용시 잘도착하는거 확인했습니다.

templates아래에있는 mail폴더안의 이메일 양식은 chatgpt로 임시로 만든거라 추후에 교체하면될거같습니다.

참고로 cert/check/{email}/{code} 에서 email의 @는 %40으로 바꿔주셔야 작동합니다.
cert/create는 무관