### PR TITLE
feat: project meeting ticket entity start

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,8 +50,32 @@ dependencies {
     *   DTO와 Entity 간의 변환을 간편하게 처리할 수 있음
     */
     implementation 'org.modelmapper:modelmapper:3.1.0'
+
+
+
+
+	//Querydsl 추가
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+
+def querydslDir = "src/main/generated"
+
+sourceSets {
+	main.java.srcDir querydslDir
+}
+
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+clean.doLast {
+	file(querydslDir).deleteDir()
 }

--- a/src/main/generated/com/org/server/meet/domain/QMeet.java
+++ b/src/main/generated/com/org/server/meet/domain/QMeet.java
@@ -1,0 +1,63 @@
+package com.org.server.meet.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMeet is a Querydsl query type for Meet
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMeet extends EntityPathBase<Meet> {
+
+    private static final long serialVersionUID = 1769737086L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QMeet meet = new QMeet("meet");
+
+    public final com.org.server.util.QBaseTime _super = new com.org.server.util.QBaseTime(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> lastModifiedDate = _super.lastModifiedDate;
+
+    public final StringPath meetUrl = createString("meetUrl");
+
+    public final com.org.server.project.domain.QProject project;
+
+    public final DateTimePath<java.time.LocalDateTime> startTime = createDateTime("startTime", java.time.LocalDateTime.class);
+
+    public QMeet(String variable) {
+        this(Meet.class, forVariable(variable), INITS);
+    }
+
+    public QMeet(Path<? extends Meet> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QMeet(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QMeet(PathMetadata metadata, PathInits inits) {
+        this(Meet.class, metadata, inits);
+    }
+
+    public QMeet(Class<? extends Meet> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.project = inits.isInitialized("project") ? new com.org.server.project.domain.QProject(forProperty("project")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/org/server/member/domain/QMember.java
+++ b/src/main/generated/com/org/server/member/domain/QMember.java
@@ -1,0 +1,61 @@
+package com.org.server.member.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = 1791407140L;
+
+    public static final QMember member = new QMember("member1");
+
+    public final com.org.server.util.QBaseTime _super = new com.org.server.util.QBaseTime(this);
+
+    public final NumberPath<Integer> birthDay = createNumber("birthDay", Integer.class);
+
+    public final NumberPath<Integer> birthMonth = createNumber("birthMonth", Integer.class);
+
+    public final NumberPath<Integer> birthYear = createNumber("birthYear", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    public final StringPath email = createString("email");
+
+    public final EnumPath<com.org.server.member.GenderType> genderType = createEnum("genderType", com.org.server.member.GenderType.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> lastModifiedDate = _super.lastModifiedDate;
+
+    public final EnumPath<com.org.server.member.MemberType> memberType = createEnum("memberType", com.org.server.member.MemberType.class);
+
+    public final StringPath nickName = createString("nickName");
+
+    public final StringPath password = createString("password");
+
+    public QMember(String variable) {
+        super(Member.class, forVariable(variable));
+    }
+
+    public QMember(Path<? extends Member> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMember(PathMetadata metadata) {
+        super(Member.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/org/server/project/domain/QProject.java
+++ b/src/main/generated/com/org/server/project/domain/QProject.java
@@ -1,0 +1,47 @@
+package com.org.server.project.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QProject is a Querydsl query type for Project
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QProject extends EntityPathBase<Project> {
+
+    private static final long serialVersionUID = -1896859752L;
+
+    public static final QProject project = new QProject("project");
+
+    public final com.org.server.util.QBaseTime _super = new com.org.server.util.QBaseTime(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> lastModifiedDate = _super.lastModifiedDate;
+
+    public final StringPath title = createString("title");
+
+    public QProject(String variable) {
+        super(Project.class, forVariable(variable));
+    }
+
+    public QProject(Path<? extends Project> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QProject(PathMetadata metadata) {
+        super(Project.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/org/server/ticket/domain/QTicket.java
+++ b/src/main/generated/com/org/server/ticket/domain/QTicket.java
@@ -1,0 +1,64 @@
+package com.org.server.ticket.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QTicket is a Querydsl query type for Ticket
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QTicket extends EntityPathBase<Ticket> {
+
+    private static final long serialVersionUID = -553663096L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QTicket ticket = new QTicket("ticket");
+
+    public final com.org.server.util.QBaseTime _super = new com.org.server.util.QBaseTime(this);
+
+    public final StringPath alias = createString("alias");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> lastModifiedDate = _super.lastModifiedDate;
+
+    public final com.org.server.member.domain.QMember member;
+
+    public final com.org.server.project.domain.QProject project;
+
+    public QTicket(String variable) {
+        this(Ticket.class, forVariable(variable), INITS);
+    }
+
+    public QTicket(Path<? extends Ticket> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QTicket(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QTicket(PathMetadata metadata, PathInits inits) {
+        this(Ticket.class, metadata, inits);
+    }
+
+    public QTicket(Class<? extends Ticket> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new com.org.server.member.domain.QMember(forProperty("member")) : null;
+        this.project = inits.isInitialized("project") ? new com.org.server.project.domain.QProject(forProperty("project")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/org/server/util/QBaseTime.java
+++ b/src/main/generated/com/org/server/util/QBaseTime.java
@@ -1,0 +1,39 @@
+package com.org.server.util;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseTime is a Querydsl query type for BaseTime
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseTime extends EntityPathBase<BaseTime> {
+
+    private static final long serialVersionUID = -1723925770L;
+
+    public static final QBaseTime baseTime = new QBaseTime("baseTime");
+
+    public final DateTimePath<java.time.LocalDateTime> createDate = createDateTime("createDate", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> lastModifiedDate = createDateTime("lastModifiedDate", java.time.LocalDateTime.class);
+
+    public QBaseTime(String variable) {
+        super(BaseTime.class, forVariable(variable));
+    }
+
+    public QBaseTime(Path<? extends BaseTime> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseTime(PathMetadata metadata) {
+        super(BaseTime.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/org/server/config/JpaConfig.java
+++ b/src/main/java/com/org/server/config/JpaConfig.java
@@ -1,0 +1,20 @@
+package com.org.server.config;
+
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/org/server/meet/controller/MeetController.java
+++ b/src/main/java/com/org/server/meet/controller/MeetController.java
@@ -1,0 +1,43 @@
+package com.org.server.meet.controller;
+
+
+
+
+import com.org.server.meet.domain.MeetConnectDto;
+import com.org.server.meet.domain.MeetDateDto;
+import com.org.server.meet.domain.MeetDto;
+import com.org.server.meet.service.MeetService;
+import com.org.server.util.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
+import java.util.List;
+
+@RestController
+@RequestMapping("/meet")
+@RequiredArgsConstructor
+public class MeetController {
+
+
+    private final MeetService meetService;
+
+    @PostMapping("/create")
+    public ResponseEntity<ApiResponse<String>> createMeet(@RequestBody MeetDto meetDto){
+        meetService.createMeet(meetDto);
+        return ResponseEntity.ok(ApiResponse.CreateApiResponse("ok",null));
+
+    }
+    @GetMapping("/checkIn/{meetId}")
+    public ResponseEntity<ApiResponse<MeetConnectDto>> checkIn(@PathVariable(name = "meetId")Long meetId){
+        return ResponseEntity.ok(ApiResponse.CreateApiResponse("ok",
+                meetService.checkIn(meetId)));
+    }
+
+    @GetMapping("/meetList/{date}")
+    public ResponseEntity<ApiResponse<List<MeetDateDto>>> getMeetList(@PathVariable(name="date")
+                                                           String date){
+        return ResponseEntity.ok(ApiResponse.CreateApiResponse("ok",
+                meetService.getMeetList(date)));
+    }
+
+}

--- a/src/main/java/com/org/server/meet/domain/Meet.java
+++ b/src/main/java/com/org/server/meet/domain/Meet.java
@@ -1,0 +1,34 @@
+package com.org.server.meet.domain;
+
+
+import com.org.server.project.domain.Project;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import com.org.server.util.BaseTime;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+
+public class Meet extends BaseTime{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    @ManyToOne(fetch =FetchType.LAZY)
+    @JoinColumn(name = "projectId")
+    private Project project;
+    private LocalDateTime startTime;
+    private String meetUrl;
+
+
+    @Builder
+    public Meet(Project project, LocalDateTime startTime, String meetUrl) {
+        this.project = project;
+        this.startTime = startTime;
+        this.meetUrl = meetUrl;
+    }
+}

--- a/src/main/java/com/org/server/meet/domain/MeetConnectDto.java
+++ b/src/main/java/com/org/server/meet/domain/MeetConnectDto.java
@@ -1,0 +1,17 @@
+package com.org.server.meet.domain;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MeetConnectDto {
+    private String meetUrl;
+    private String alias;
+
+    public MeetConnectDto(String meetUrl, String alias) {
+        this.meetUrl = meetUrl;
+        this.alias = alias;
+    }
+}

--- a/src/main/java/com/org/server/meet/domain/MeetDateDto.java
+++ b/src/main/java/com/org/server/meet/domain/MeetDateDto.java
@@ -1,0 +1,31 @@
+package com.org.server.meet.domain;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MeetDateDto {
+
+
+    private Long meetId;
+    private Long projectId;
+    private String title;
+    private String date;
+
+
+    public void updateDate(String date){
+        this.date=date;
+    }
+
+    @Builder
+    public MeetDateDto(Long meetId, Long projectId, String title, String date) {
+        this.meetId = meetId;
+        this.projectId = projectId;
+        this.title = title;
+        this.date = date;
+    }
+}

--- a/src/main/java/com/org/server/meet/domain/MeetDto.java
+++ b/src/main/java/com/org/server/meet/domain/MeetDto.java
@@ -1,0 +1,18 @@
+package com.org.server.meet.domain;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MeetDto {
+
+    private Long projectId;
+    private String startTime;
+
+    public MeetDto(Long projectId, String startTime) {
+        this.projectId = projectId;
+        this.startTime = startTime;
+    }
+}

--- a/src/main/java/com/org/server/meet/repository/MeetAdvanceRepo.java
+++ b/src/main/java/com/org/server/meet/repository/MeetAdvanceRepo.java
@@ -1,0 +1,51 @@
+package com.org.server.meet.repository;
+
+
+import com.org.server.meet.domain.Meet;
+import com.org.server.meet.domain.MeetDateDto;
+import com.org.server.meet.domain.QMeet;
+import com.org.server.project.domain.Project;
+import com.org.server.project.domain.QProject;
+import com.org.server.ticket.domain.QTicket;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.org.server.member.domain.Member;
+import java.time.LocalDateTime;
+import java.util.List;
+import static com.org.server.meet.domain.QMeet.*;
+import static com.org.server.member.domain.QMember.member;
+import static com.org.server.project.domain.QProject.*;
+import static com.org.server.ticket.domain.QTicket.*;
+
+
+@Repository
+@RequiredArgsConstructor
+public class MeetAdvanceRepo {
+
+    private final JPAQueryFactory queryFactory;
+
+
+
+    public List<MeetDateDto> getMeetList(LocalDateTime startTime, LocalDateTime endTime, Member m){
+            return queryFactory.select(Projections.constructor(MeetDateDto.class,
+                            meet.id,
+                            project.id,
+                            project.title,
+                            meet.startTime.stringValue()
+                            ))
+                    .from(ticket)
+                    .join(project)
+                    .on(project.eq(ticket.project))
+                    .join(member)
+                    .on(member.eq(ticket.member))
+                    .join(meet)
+                    .on(meet.project.eq(project))
+                    .where(meet.startTime.goe(startTime).and(meet.startTime.lt(endTime))
+                            .and(member.eq(m)))
+                    .fetch();
+
+    }
+
+}

--- a/src/main/java/com/org/server/meet/repository/MeetRepository.java
+++ b/src/main/java/com/org/server/meet/repository/MeetRepository.java
@@ -1,0 +1,8 @@
+package com.org.server.meet.repository;
+
+import com.org.server.meet.domain.Meet;
+import org.springframework.data.jpa.repository.JpaRepository;
+public interface MeetRepository extends JpaRepository<Meet,Long>{
+
+
+}

--- a/src/main/java/com/org/server/meet/service/MeetService.java
+++ b/src/main/java/com/org/server/meet/service/MeetService.java
@@ -1,0 +1,89 @@
+package com.org.server.meet.service;
+
+
+import com.org.server.exception.MoiraException;
+import com.org.server.meet.domain.Meet;
+import com.org.server.meet.domain.MeetConnectDto;
+import com.org.server.meet.domain.MeetDateDto;
+import com.org.server.meet.domain.MeetDto;
+import com.org.server.meet.repository.MeetAdvanceRepo;
+import com.org.server.meet.repository.MeetRepository;
+import com.org.server.member.service.SecurityMemberReadService;
+import com.org.server.project.domain.Project;
+import com.org.server.project.repository.ProjectRepository;
+import com.org.server.ticket.domain.Ticket;
+import com.org.server.ticket.repository.TicketRepository;
+import com.org.server.util.DateTimeMapUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.org.server.util.RandomCharSet;
+import java.util.Optional;
+import java.time.LocalDateTime;
+import com.org.server.member.domain.Member;
+import java.util.List;
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MeetService {
+
+    private final MeetRepository meetRepository;
+    private final ProjectRepository projectRepository;
+    private final MeetAdvanceRepo meetAdvanceRepo;
+    private final SecurityMemberReadService securityMemberReadService;
+    private final TicketRepository ticketRepository;
+
+    public void createMeet(MeetDto meetDto){
+
+        Project project=projectRepository.findById(meetDto.getProjectId()).get();
+        String meetUrl=RandomCharSet.createRandomName();
+        LocalDateTime startTime=LocalDateTime.parse(meetDto.getStartTime(),
+                DateTimeMapUtil.formatByDot);
+        Meet m=Meet.builder()
+                .project(project)
+                .meetUrl(meetUrl)
+                .startTime(startTime)
+                .build();
+        meetRepository.save(m);
+
+    }
+
+    public MeetConnectDto checkIn(Long id) {
+        LocalDateTime now = LocalDateTime.now();
+        Optional<Meet> meet = meetRepository.findById(id);
+        if (meet.isEmpty()) {
+            throw new MoiraException("존재하지 않는 회의입니다", HttpStatus.BAD_REQUEST);
+        }
+        if (now.isBefore(meet.get().getStartTime())) {
+            throw new MoiraException("회의 시간 전입니다", HttpStatus.BAD_REQUEST);
+        }
+        Member m = securityMemberReadService.securityMemberRead();
+        if (ticketRepository.existsByMemberIdAndProjectId(m.getId(), meet.get().getProject().getId())) {
+            Ticket t = ticketRepository.findByMemberIdAndProjectId(m.getId(),
+                    meet.get().getProject().getId()).get();
+
+            return new MeetConnectDto(meet.get().getMeetUrl(), t.getAlias()==null ?
+                    m.getNickName() :t.getAlias());
+        }
+        throw new MoiraException("참가할수없는 회의입니다", HttpStatus.BAD_REQUEST);
+    }
+
+    public List<MeetDateDto> getMeetList(String date){
+        LocalDateTime startTime=LocalDate.parse(date,DateTimeMapUtil.formatByDot2).atStartOfDay();
+        LocalDateTime endTime=startTime.plusMonths(1L);
+        Member m=securityMemberReadService.securityMemberRead();
+
+        List<MeetDateDto> meetList=meetAdvanceRepo.getMeetList(startTime,endTime,m);
+
+        meetList.forEach(x->{
+            x.updateDate(DateTimeMapUtil.provideTimePattern(x.getDate()));
+
+        });
+
+        return meetList;
+
+    }
+}

--- a/src/main/java/com/org/server/member/domain/Member.java
+++ b/src/main/java/com/org/server/member/domain/Member.java
@@ -4,12 +4,10 @@ package com.org.server.member.domain;
 import com.org.server.member.GenderType;
 import com.org.server.member.MemberType;
 import com.org.server.util.BaseTime;
-
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.criteria.CriteriaBuilder;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/org/server/project/controller/ProjectController.java
+++ b/src/main/java/com/org/server/project/controller/ProjectController.java
@@ -1,0 +1,35 @@
+package com.org.server.project.controller;
+
+
+import org.springframework.http.ResponseEntity;
+import com.org.server.project.service.ProjectService;
+import com.org.server.util.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import com.org.server.project.domain.ProjectDto;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/project")
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+
+    @PostMapping("/create")
+    public ResponseEntity<ApiResponse<String>> createProject(@RequestBody ProjectDto projectDto){
+        projectService.createProject(projectDto.getTitle());
+        return ResponseEntity.ok(ApiResponse.CreateApiResponse("ok",null));
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<ApiResponse<List<ProjectDto>>> getProjectList(){
+        return ResponseEntity.ok(ApiResponse.CreateApiResponse("ok",
+                projectService.getProjectList()));
+    }
+
+
+
+}

--- a/src/main/java/com/org/server/project/domain/Project.java
+++ b/src/main/java/com/org/server/project/domain/Project.java
@@ -1,0 +1,24 @@
+package com.org.server.project.domain;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import com.org.server.util.BaseTime;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Project extends BaseTime{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    @Column(nullable = false)
+    private String title;
+
+
+    public Project(String title) {
+        this.title = title;
+    }
+}

--- a/src/main/java/com/org/server/project/domain/ProjectDto.java
+++ b/src/main/java/com/org/server/project/domain/ProjectDto.java
@@ -1,0 +1,24 @@
+package com.org.server.project.domain;
+
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProjectDto {
+
+
+    private Long id;
+    @NotBlank(message = "비어선 안됩니다")
+    @Max(value =15,message = "최대 15글가까지입니다")
+    private String title;
+
+    public ProjectDto(Long id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+}

--- a/src/main/java/com/org/server/project/repository/ProjectAdvanceRepo.java
+++ b/src/main/java/com/org/server/project/repository/ProjectAdvanceRepo.java
@@ -1,0 +1,39 @@
+package com.org.server.project.repository;
+
+
+import com.org.server.project.domain.Project;
+import com.org.server.project.domain.ProjectDto;
+import com.org.server.ticket.domain.QTicket;
+import com.querydsl.core.types.Projections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.org.server.member.domain.Member;
+import java.util.List;
+
+import static com.org.server.member.domain.QMember.member;
+import static com.org.server.project.domain.QProject.project;
+import static com.org.server.ticket.domain.QTicket.*;
+
+@Repository
+@RequiredArgsConstructor
+public class ProjectAdvanceRepo {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<ProjectDto> getProjectList(Member m){
+            List<ProjectDto> projectDtoList=queryFactory
+                    .select(Projections.constructor(ProjectDto.class,
+                            project.id,
+                            project.title
+                            ))
+                    .from(ticket)
+                    .join(member)
+                    .on(ticket.member.eq(member))
+                    .join(project)
+                    .on(ticket.project.eq(project))
+                    .where(member.eq(m))
+                    .fetch();
+            return projectDtoList;
+    }
+}

--- a/src/main/java/com/org/server/project/repository/ProjectRepository.java
+++ b/src/main/java/com/org/server/project/repository/ProjectRepository.java
@@ -1,0 +1,6 @@
+package com.org.server.project.repository;
+
+import com.org.server.project.domain.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+public interface ProjectRepository extends JpaRepository<Project,Long>{
+}

--- a/src/main/java/com/org/server/project/service/ProjectService.java
+++ b/src/main/java/com/org/server/project/service/ProjectService.java
@@ -1,0 +1,35 @@
+package com.org.server.project.service;
+
+
+import com.org.server.member.service.SecurityMemberReadService;
+import com.org.server.project.domain.Project;
+import com.org.server.project.domain.ProjectDto;
+import com.org.server.project.repository.ProjectAdvanceRepo;
+import com.org.server.project.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import com.org.server.member.domain.Member;
+
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+    private final SecurityMemberReadService securityMemberReadService;
+    private final ProjectAdvanceRepo projectAdvanceRepo;
+    public void createProject(String title){
+        Project project=new Project(title);
+        projectRepository.save(project);
+    }
+
+    public List<ProjectDto> getProjectList(){
+        Member m=securityMemberReadService.securityMemberRead();
+        return projectAdvanceRepo.getProjectList(m);
+    }
+
+}

--- a/src/main/java/com/org/server/ticket/controller/TicketController.java
+++ b/src/main/java/com/org/server/ticket/controller/TicketController.java
@@ -1,0 +1,39 @@
+package com.org.server.ticket.controller;
+
+
+import com.org.server.ticket.domain.TicketDto;
+import com.org.server.ticket.service.TicketService;
+import com.org.server.util.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/ticket")
+@RequiredArgsConstructor
+public class TicketController {
+
+    private final TicketService ticketService;
+
+    @GetMapping("/checkIn/{projectId}")
+    public ResponseEntity<ApiResponse<Boolean>> checkIn(
+            @PathVariable(value = "projectId")Long projectId){
+        return ResponseEntity.ok(ApiResponse.CreateApiResponse("ok",
+                ticketService.checkIn(projectId)));
+    }
+
+    @PostMapping("/create")
+    public ResponseEntity<ApiResponse<String>> createTicket(@RequestBody TicketDto ticketDto){
+        ticketService.createTicket(ticketDto);
+        return ResponseEntity.ok(ApiResponse.CreateApiResponse("ok",null));
+    }
+
+    @PostMapping("/change/alias/{projectId}/{alias}")
+    public ResponseEntity<ApiResponse<String>> changeAlias(@PathVariable(name = "alias")
+                                                           String alias,@PathVariable(name ="projectId")
+                                                           Long projectId){
+        ticketService.changeAlias(alias,projectId);
+        return ResponseEntity.ok(ApiResponse.CreateApiResponse("ok",null));
+    }
+
+}

--- a/src/main/java/com/org/server/ticket/domain/Ticket.java
+++ b/src/main/java/com/org/server/ticket/domain/Ticket.java
@@ -1,0 +1,43 @@
+package com.org.server.ticket.domain;
+
+
+import com.org.server.project.domain.Project;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import com.org.server.util.BaseTime;
+import com.org.server.member.domain.Member;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(uniqueConstraints =  @UniqueConstraint(columnNames = {"memberId", "projectId"}))
+public class Ticket extends BaseTime{
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "projectId")
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberId")
+    private Member member;
+
+    private String alias;
+
+    @Builder
+    public Ticket(Project project, Member member, String alias) {
+        this.project = project;
+        this.member = member;
+        this.alias = alias;
+    }
+
+    public void updateAlias(String alias){
+        this.alias=alias;
+    }
+}

--- a/src/main/java/com/org/server/ticket/domain/TicketDto.java
+++ b/src/main/java/com/org/server/ticket/domain/TicketDto.java
@@ -1,0 +1,14 @@
+package com.org.server.ticket.domain;
+
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TicketDto {
+    private Long id;
+    private String email;
+    private String alias;
+}

--- a/src/main/java/com/org/server/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/org/server/ticket/repository/TicketRepository.java
@@ -1,0 +1,12 @@
+package com.org.server.ticket.repository;
+
+import com.org.server.ticket.domain.Ticket;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TicketRepository extends JpaRepository<Ticket,Long>{
+    Boolean existsByMemberIdAndProjectId(Long memberId,Long projectId);
+
+    Optional<Ticket> findByMemberIdAndProjectId(Long memberId,Long projectId);
+}

--- a/src/main/java/com/org/server/ticket/service/TicketService.java
+++ b/src/main/java/com/org/server/ticket/service/TicketService.java
@@ -1,0 +1,59 @@
+package com.org.server.ticket.service;
+
+
+import com.org.server.exception.MoiraException;
+import com.org.server.member.service.SecurityMemberReadService;
+import com.org.server.project.domain.Project;
+import com.org.server.project.repository.ProjectRepository;
+import com.org.server.ticket.domain.Ticket;
+import com.org.server.ticket.domain.TicketDto;
+import com.org.server.ticket.repository.TicketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.org.server.member.domain.Member;
+import com.org.server.member.repository.MemberRepository;
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TicketService {
+
+    private final TicketRepository ticketRepository;
+    private final SecurityMemberReadService securityMemberReadService;
+    private final MemberRepository memberRepository;
+    private final ProjectRepository projectRepository;
+
+
+
+    public Boolean checkIn(Long projectId){
+        Member m=securityMemberReadService.securityMemberRead();
+        return ticketRepository.existsByMemberIdAndProjectId(m.getId(),projectId);
+    }
+
+    public void createTicket(TicketDto ticketDto){
+
+        Project project=projectRepository.findById(ticketDto.getId()).get();
+        Member m=memberRepository.findByEmail(ticketDto.getEmail()).get();
+
+        if(ticketRepository.existsByMemberIdAndProjectId(m.getId(),project.getId())){
+            throw new MoiraException("이미 초대된 유저입니다", HttpStatus.BAD_REQUEST);
+        }
+
+        Ticket ticket= new Ticket(project,m,ticketDto.getAlias());
+        ticketRepository.save(ticket);
+    }
+
+    public void changeAlias(String alias,Long projectId){
+        Member m=securityMemberReadService.securityMemberRead();
+        Optional<Ticket> ticket=
+                ticketRepository.findByMemberIdAndProjectId(m.getId(),projectId);
+
+        if(ticket.isEmpty()){
+            throw new MoiraException("해당 권한이없습니다",HttpStatus.BAD_REQUEST);
+        }
+        ticket.get().updateAlias(alias);
+        return ;
+    }
+}

--- a/src/main/java/com/org/server/util/DateTimeMapUtil.java
+++ b/src/main/java/com/org/server/util/DateTimeMapUtil.java
@@ -1,0 +1,47 @@
+package com.org.server.util;
+
+import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.util.Date;
+
+public class DateTimeMapUtil {
+
+    public final static DateTimeFormatter formatByDot =
+            DateTimeFormatter.ofPattern("yyyy.MM.dd.HH.mm");
+    public final static DateTimeFormatter formatByDot2 =
+            DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+    public static final DateTimeFormatter FLEXIBLE_NANO_FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd HH:mm:ss") // 기본 날짜-시간 패턴
+            .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true) // 소수점 초 (나노초)를 0~9자리까지 선택적으로 추가
+            .toFormatter();
+
+    public static final String provideTimePattern(String date){
+        return formatByDot2
+                .format(LocalDateTime.parse(date
+                        ,FLEXIBLE_NANO_FORMATTER));
+
+    }
+
+
+
+    public static String dateFormat(Date date, String mysqlFormatPattern) {
+        if (date == null) {
+            return null;
+        }
+        // MySQL 패턴을 Java SimpleDateFormat 패턴으로 변환
+        String javaFormatPattern = mysqlFormatPattern
+                .replace("%Y", "yyyy")
+                .replace("%m", "MM")
+                .replace("%d", "dd")
+                .replace("%H", "HH") // 시 (00-23)
+                .replace("%i", "mm") // 분 (00-59)
+                .replace("%s", "ss"); // 초 (00-59)
+
+        SimpleDateFormat sdf = new SimpleDateFormat(javaFormatPattern);
+        return sdf.format(date);
+    }
+}

--- a/src/test/java/com/org/server/ProjectTicketMeetTest/ProjectMeetTicket.java
+++ b/src/test/java/com/org/server/ProjectTicketMeetTest/ProjectMeetTicket.java
@@ -1,0 +1,137 @@
+package com.org.server.ProjectTicketMeetTest;
+
+
+import com.org.server.meet.domain.Meet;
+import com.org.server.meet.domain.MeetConnectDto;
+import com.org.server.meet.domain.MeetDateDto;
+import com.org.server.meet.domain.MeetDto;
+import com.org.server.project.domain.Project;
+import com.org.server.project.domain.ProjectDto;
+import com.org.server.security.domain.CustomUserDetail;
+import com.org.server.support.IntegralTestEnv;
+import com.org.server.ticket.domain.Ticket;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import com.org.server.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import static org.assertj.core.api.Assertions.*;
+
+public class ProjectMeetTicket extends IntegralTestEnv {
+
+
+    Project p;
+
+    Project p2;
+
+    Ticket t;
+
+    Member m;
+
+
+
+    private static DataSource testDataSource;
+
+
+
+    @BeforeAll
+    static void setupH2CustomFunctions(@Autowired DataSource dataSource) {
+        testDataSource = dataSource; //
+        try (Connection conn = testDataSource.getConnection();
+             Statement stmt = conn.createStatement()) {
+
+            stmt.execute("CREATE ALIAS IF NOT EXISTS DATE_FORMAT FOR 'com.org.server.util.DateTimeMapUtil.dateFormat'");
+            System.out.println("H2에 DATE_FORMAT 함수 별칭이 성공적으로 등록되었습니다.");
+        } catch (SQLException e) {
+            System.err.println("H2 함수 별칭 등록 중 오류 발생: " + e.getMessage());
+            e.printStackTrace();
+
+            throw new RuntimeException("Failed to register H2 DATE_FORMAT alias", e);
+        }
+    }
+
+
+
+
+    @BeforeEach
+    void settings(){
+
+        m=createMember(1L);
+        Member m2=createMember(2L);
+        Mockito.when(securityMemberReadService.securityMemberRead())
+                .thenReturn(m);
+        p=createProject("test");
+        p2=createProject("test2");
+        t=createTicket(m,p,null);
+        createTicket(m2,p2,"p2");
+        String startTime="2025.09.16.00.00";
+
+        for(int i=0;5>i;i++) {
+            meetService.createMeet(new MeetDto(p.getId(),startTime));
+        }
+        for(int i=0;5>i;i++) {
+            meetService.createMeet(new MeetDto(p2.getId(),startTime));
+        }
+    }
+
+    @Test
+    @DisplayName("해당되는 project를 잘가져오는가.")
+    void callProjectsTest(){
+
+
+        Mockito.when(securityMemberReadService.securityMemberRead())
+                .thenReturn(m);
+
+        List<ProjectDto> projectDtoList=projectService.getProjectList();
+        assertThat(projectDtoList.size()).isEqualTo(1);
+    }
+    @Test
+    @DisplayName("해당되는 meeting 내역을 잘가져오는가.")
+    void callMeetTest() {
+
+
+        Mockito.when(securityMemberReadService.securityMemberRead())
+                .thenReturn(m);
+
+        List<MeetDateDto> meetDateDtos = meetService.getMeetList("2025.09.01");
+        assertThat(meetDateDtos.size()).isEqualTo(5);
+
+        List<MeetDateDto> meetDateDtos2 = meetService.getMeetList("2025.10.01");
+        assertThat(meetDateDtos2.size()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("ticket alias 변경 체크")
+    void noAuthTest(){
+
+        Mockito.when(securityMemberReadService.securityMemberRead())
+                .thenReturn(m);
+
+
+        ticketService.changeAlias("change",p.getId());
+        Ticket t2=ticketRepository.findById(t.getId()).get();
+        assertThat(t2.getAlias()).isEqualTo("change");
+    }
+
+    @Test
+    @DisplayName("alias 미지정시 날라오는 이름체크")
+    void aliasTest(){
+
+        Mockito.when(securityMemberReadService.securityMemberRead())
+                .thenReturn(m);
+        List<Meet> meets=meetRepository.findAll();
+        MeetConnectDto meetConnectDto=meetService.checkIn(meets.getFirst().getId());
+        assertThat(meetConnectDto.getAlias()).isEqualTo("test1");
+    }
+}

--- a/src/test/java/com/org/server/member/MemberCreateTest.java
+++ b/src/test/java/com/org/server/member/MemberCreateTest.java
@@ -17,9 +17,7 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import static org.assertj.core.api.Assertions.*;
-import static org.springframework.mock.http.server.reactive.MockServerHttpRequest.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 @AutoConfigureMockMvc
 public class MemberCreateTest extends IntegralTestEnv {
@@ -77,6 +75,10 @@ public class MemberCreateTest extends IntegralTestEnv {
         SecurityContext securityContext = Mockito.mock(SecurityContext.class);
         Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
         SecurityContextHolder.setContext(securityContext);
+
+
+        Mockito.when(securityMemberReadService.securityMemberRead())
+                .thenReturn(member);
 
         MemberUpdateDto memberUpdateDto=new MemberUpdateDto(
                 member.getId(),

--- a/src/test/java/com/org/server/support/IntegralTestEnv.java
+++ b/src/test/java/com/org/server/support/IntegralTestEnv.java
@@ -3,17 +3,27 @@ package com.org.server.support;
 
 import com.org.server.certification.CertificationTest;
 import com.org.server.certification.service.CertificationService;
+import com.org.server.meet.domain.Meet;
+import com.org.server.meet.repository.MeetRepository;
+import com.org.server.meet.service.MeetService;
 import com.org.server.member.MemberType;
 import com.org.server.member.domain.Member;
 import com.org.server.member.repository.MemberRepository;
 import com.org.server.member.service.MemberServiceImpl;
 import com.org.server.member.service.SecurityMemberReadService;
+import com.org.server.project.domain.Project;
+import com.org.server.project.repository.ProjectRepository;
+import com.org.server.project.service.ProjectService;
 import com.org.server.redis.service.RedisUserInfoService;
+import com.org.server.ticket.domain.Ticket;
+import com.org.server.ticket.repository.TicketRepository;
+import com.org.server.ticket.service.TicketService;
 import com.org.server.util.jwt.JwtUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -30,18 +40,33 @@ public class IntegralTestEnv {
     @Autowired
     protected MemberRepository memberRepository;
 
+    @Autowired
+    protected TicketRepository ticketRepository;
+
+    @Autowired
+    protected MeetRepository meetRepository;
+
+    @Autowired
+    protected ProjectRepository projectRepository;
+
 
     //service
 
     @Autowired
     protected MemberServiceImpl memberService;
-    @Autowired
+    @MockitoBean
     protected SecurityMemberReadService securityMemberReadService;
 
     @Autowired
     protected CertificationService certificationService;
     @MockitoBean
     protected RedisUserInfoService redisUserInfoService;
+    @Autowired
+    protected MeetService meetService;
+    @Autowired
+    protected ProjectService projectService;
+    @Autowired
+    protected TicketService ticketService;
 
     @Autowired
     protected JwtUtil jwtUtil;
@@ -56,6 +81,10 @@ public class IntegralTestEnv {
     protected SpringTemplateEngine springTemplateEngine;
     @AfterEach
     void deleteAll(){
+
+        ticketRepository.deleteAllInBatch();
+        meetRepository.deleteAllInBatch();
+        projectRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
     }
 
@@ -72,4 +101,19 @@ public class IntegralTestEnv {
         member=memberRepository.save(member);
         return member;
     }
+    protected Ticket createTicket(Member m, Project p,String alias){
+        Ticket t=Ticket.builder()
+                .member(m)
+                .project(p)
+                .alias(alias)
+                .build();
+        t=ticketRepository.save(t);
+        return t;
+    }
+    protected Project createProject(String title){
+        Project p=new Project(title);
+        return projectRepository.save(p);
+    }
+
+
 }


### PR DESCRIPTION
project,meet,ticket 객체 관련 생성 및관리 조회 메서드를 만들었습니다.
아직 삭제에대한 판정을 논의하지않아서 삭제는 제외하였습니다.

중간에 post인대 pathvariable로 받아서 처리하는 메서드가있는대 우선 서버상태를 바꾸니까 post로 한개 맞기한대
편의를 위해서 그냥 pathvariable로 처리했습니다.


https://www.erdcloud.com/d/ah22pNifWPkRD9f29

해당 엔티티를 구성하면서 만들어놓은 erd 입니다. 해당 erd를 기반으로 구현하였고 질문사항이나 의문점이 존재하신다면 호출해주시면되겠습니다.


간략하게 의도를 설명해보자면

Project 객체는 사람들이 모이는 가장큰 단위라고 가정을 하고 진행했습니다.
회의에 해당되는 meeting이라던가 혹은 해당 회의의 결과물인 white board모두 project 객체가 존재하기에 진행할수 있기 때문입니다.


Meet 객체는 회의 객체로 사람들이 모이는 가장 작은 단위입니다.
1개의 프로젝트에 대해서 여러개의 meet 객체가 생성될수있기에 1:다로 구성하였습니다.

white board결과물에 해당되는 page 객체입니다.
1개의 회의에 page객체 1개가 연결됩니다.(애는 사실 아직 구현은 안했습니다.)

ticket 객체는 프로젝트 및 미팅에 참여시 해당 회원이 이 프로젝트,회의에 참여할수있는 회원인지를 판별하는 객체입니다.
projectid와 memberid를 한개로 묶어서 unique키로 만들었습니다.
